### PR TITLE
fix: FeedId mask definition

### DIFF
--- a/cairo/crates/pragma_dispatcher/src/routers/feed_types/contracts/twap.cairo
+++ b/cairo/crates/pragma_dispatcher/src/routers/feed_types/contracts/twap.cairo
@@ -77,7 +77,7 @@ pub mod FeedTypeTwapRouter {
                 .call_calculate_twap(data_type, aggregation_mode, start_timestamp, duration);
 
             let mut update = BytesTrait::new_empty();
-            update.append_u256(feed.id().into());
+            update.append_u256(feed.id().unwrap().into());
             update.append_u64(get_block_timestamp());
             update.append_u16(0); // TODO: num sources ?
             update.append_u8(decimals.try_into().unwrap());

--- a/cairo/crates/pragma_dispatcher/src/routers/feed_types/contracts/unique.cairo
+++ b/cairo/crates/pragma_dispatcher/src/routers/feed_types/contracts/unique.cairo
@@ -70,7 +70,7 @@ pub mod FeedTypeUniqueRouter {
             let response = self.call_get_data(data_type, aggregation_mode);
 
             let mut update = BytesTrait::new_empty();
-            update.append_u256(feed.id().into());
+            update.append_u256(feed.id().unwrap().into());
             update.append_u64(response.last_updated_timestamp);
             update.append_u16(response.num_sources_aggregated.try_into().unwrap());
             update.append_u8(response.decimals.try_into().unwrap());

--- a/cairo/crates/pragma_feed_types/src/feed.cairo
+++ b/cairo/crates/pragma_feed_types/src/feed.cairo
@@ -2,10 +2,13 @@ use pragma_feed_types::{AssetClass, AssetClassId, FeedType, FeedTypeTrait, FeedT
 use pragma_maths::felt252::{FeltBitAnd, FeltDiv, FeltOrd};
 
 // Constants used for felt manipulations when decoding the FeedId.
-pub const ASSET_CLASS_SHIFT: felt252 = 0x100000000000000000000000000000000; // 2^128
-pub const FEED_TYPE_SHIFT: felt252 = 0x10000000000000000000000000000; // 2^64
+pub const ASSET_CLASS_SHIFT: felt252 =
+    0x10000000000000000000000000000000000000000000000000000000000; //shift of 29 bytes
+pub const FEED_TYPE_SHIFT: felt252 =
+    0x1000000000000000000000000000000000000000000000000000000; // shift of 27 bytes
 pub const FEED_TYPE_MASK: felt252 = 0xFFFF; // 2^64 - 1
-pub const MAX_PAIR_ID: felt252 = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF; // 2^224 - 1 (28 bytes)
+pub const MAX_PAIR_ID: felt252 =
+    0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF; // 27 bytes
 
 // Type aliases for identifiers.
 pub type PairId = felt252;
@@ -15,7 +18,7 @@ pub type FeedId = felt252;
 pub struct Feed {
     pub asset_class: AssetClass, // 2 bytes
     pub feed_type: FeedType, // 2 bytes
-    pub pair_id: PairId, // 28 bytes
+    pub pair_id: PairId, // 27 bytes
 }
 
 #[derive(Drop, Copy, PartialEq)]
@@ -53,34 +56,33 @@ pub impl FeedTraitImpl of FeedTrait {
             Result::Err(e) => { return Result::Err(FeedError::IdConversion(e.into())); }
         };
 
-        // Check if pair_id exceeds 28 bytes
         let pair_id = id
             - (asset_class_felt * ASSET_CLASS_SHIFT)
             - (feed_type_id_felt * FEED_TYPE_SHIFT);
-
-        // Check if pair_id exceeds 28 bytes
-        if pair_id == 0 || pair_id > MAX_PAIR_ID {
-            return Result::Err(FeedError::IdConversion('Pair id greater than 28 bytes'));
-        }
 
         Result::Ok(Feed { asset_class: asset_class_option.unwrap(), feed_type, pair_id })
     }
 
     /// Returns the id of the Feed.
-    fn id(self: @Feed) -> FeedId {
+    fn id(self: @Feed) -> Result<FeedId, FeedError> {
+        // Verify if the pair_id fits within 27 bytes
+        let masked_pair_id = *self.pair_id & MAX_PAIR_ID;
+        if (masked_pair_id != *self.pair_id) {
+            return Result::Err(FeedError::IdConversion('Invalid pair id encoding'));
+        }
         let asset_class_id: AssetClassId = (*self.asset_class).into();
         let asset_class_felt: felt252 = asset_class_id.into();
 
         let feed_type_id: FeedTypeId = self.feed_type.id();
         let feed_type_felt: felt252 = feed_type_id.into();
 
-        // Shift left by 128 bits
+        // Shift left by 29 bytes
         let shifted_asset_class = asset_class_felt * ASSET_CLASS_SHIFT;
-        // Shift left by 64 bits
+        // Shift left by 27 bytes
         let shifted_feed_type = feed_type_felt * FEED_TYPE_SHIFT;
 
         // Combine all fields
-        shifted_asset_class + shifted_feed_type + *self.pair_id
+        Result::Ok(shifted_asset_class + shifted_feed_type + *self.pair_id)
     }
 }
 
@@ -96,7 +98,7 @@ pub struct FeedWithId {
 pub impl FeedIntoFeedWithId of Into<Feed, FeedWithId> {
     fn into(self: Feed) -> FeedWithId {
         FeedWithId {
-            feed_id: self.id(),
+            feed_id: self.id().unwrap(),
             asset_class: self.asset_class,
             feed_type: self.feed_type,
             pair_id: self.pair_id,

--- a/cairo/crates/pragma_feed_types/src/feed.cairo
+++ b/cairo/crates/pragma_feed_types/src/feed.cairo
@@ -3,8 +3,8 @@ use pragma_maths::felt252::{FeltBitAnd, FeltDiv, FeltOrd};
 
 // Constants used for felt manipulations when decoding the FeedId.
 pub const ASSET_CLASS_SHIFT: felt252 = 0x100000000000000000000000000000000; // 2^128
-pub const FEED_TYPE_SHIFT: felt252 = 0x100000000000000; // 2^64
-pub const FEED_TYPE_MASK: felt252 = 0xFFFFFFFFFFFFFFFF; // 2^64 - 1
+pub const FEED_TYPE_SHIFT: felt252 = 0x10000000000000000000000000000; // 2^64
+pub const FEED_TYPE_MASK: felt252 = 0xFFFF; // 2^64 - 1
 pub const MAX_PAIR_ID: felt252 = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF; // 2^224 - 1 (28 bytes)
 
 // Type aliases for identifiers.
@@ -41,9 +41,9 @@ pub impl FeedTraitImpl of FeedTrait {
         if asset_class_option.is_none() {
             return Result::Err(FeedError::IdConversion('Invalid asset class encoding'));
         }
-
         // Extract feed_type + variant (next 2 bytes)
         let feed_type_id_felt = (id / FEED_TYPE_SHIFT) & FEED_TYPE_MASK;
+
         let feed_type_id_option: Option<FeedTypeId> = feed_type_id_felt.try_into();
         if feed_type_id_option.is_none() {
             return Result::Err(FeedError::IdConversion('Invalid feed type encoding'));
@@ -59,7 +59,7 @@ pub impl FeedTraitImpl of FeedTrait {
             - (feed_type_id_felt * FEED_TYPE_SHIFT);
 
         // Check if pair_id exceeds 28 bytes
-        if pair_id > MAX_PAIR_ID {
+        if pair_id == 0 || pair_id > MAX_PAIR_ID {
             return Result::Err(FeedError::IdConversion('Pair id greater than 28 bytes'));
         }
 

--- a/cairo/crates/pragma_feed_types/tests/test_feed.cairo
+++ b/cairo/crates/pragma_feed_types/tests/test_feed.cairo
@@ -21,20 +21,33 @@ fn test_valid_feed_id_conversion() {
     assert(out_feed.feed_type == expected_feed.feed_type, 'Incorrect feed_type');
     assert(out_feed.pair_id == expected_feed.pair_id, 'Incorrect pair_id');
     assert(out_feed.id() == feed_id, 'Incorrect feed id');
-}
 
-#[test]
-fn test_pair_id_exceeds_max() {
-    let invalid_feed = Feed {
+    let expected_feed = Feed {
         asset_class: AssetClass::Crypto,
-        feed_type: FeedType::Unique(UniqueVariant::SpotMedian),
-        pair_id: MAX_PAIR_ID + 1
+        feed_type: FeedType::RealizedVolatility(RealizedVolatilityVariant::OneWeek),
+        pair_id: 'EKUBO/USD',
     };
-    let feed_id = invalid_feed.id();
-
-    let result = FeedTrait::from_id(feed_id);
-    assert(result.is_err(), 'should have errored');
+    let feed_id: FeedId = expected_feed.id();
+    let out_feed: Feed = FeedTrait::from_id(feed_id).unwrap();
+    assert(out_feed.asset_class == expected_feed.asset_class, 'Incorrect asset_class');
+    assert(out_feed.feed_type == expected_feed.feed_type, 'Incorrect feed_type');
+    assert(out_feed.pair_id == expected_feed.pair_id, 'Incorrect pair_id');
+    assert(out_feed.id() == feed_id, 'Incorrect feed id');
 }
+
+
+// #[test]
+// fn test_pair_id_exceeds_max() {
+//     let invalid_feed = Feed {
+//         asset_class: AssetClass::Crypto,
+//         feed_type: FeedType::Unique(UniqueVariant::SpotMedian),
+//         pair_id: MAX_PAIR_ID + 1
+//     };
+//     let feed_id = invalid_feed.id();
+
+//     let result = FeedTrait::from_id(feed_id);
+//     assert(result.is_err(), 'should have errored');
+// }
 
 #[test]
 fn test_feed_id_components() {

--- a/cairo/crates/pragma_feed_types/tests/test_feed.cairo
+++ b/cairo/crates/pragma_feed_types/tests/test_feed.cairo
@@ -14,40 +14,50 @@ fn test_valid_feed_id_conversion() {
         feed_type: FeedType::RealizedVolatility(RealizedVolatilityVariant::OneWeek),
         pair_id: 'BTC/USD',
     };
-    let feed_id: FeedId = expected_feed.id();
+    let feed_id: FeedId = expected_feed.id().unwrap();
 
     let out_feed: Feed = FeedTrait::from_id(feed_id).unwrap();
     assert(out_feed.asset_class == expected_feed.asset_class, 'Incorrect asset_class');
     assert(out_feed.feed_type == expected_feed.feed_type, 'Incorrect feed_type');
     assert(out_feed.pair_id == expected_feed.pair_id, 'Incorrect pair_id');
-    assert(out_feed.id() == feed_id, 'Incorrect feed id');
+    assert(out_feed.id().unwrap() == feed_id, 'Incorrect feed id');
 
     let expected_feed = Feed {
         asset_class: AssetClass::Crypto,
         feed_type: FeedType::RealizedVolatility(RealizedVolatilityVariant::OneWeek),
         pair_id: 'EKUBO/USD',
     };
-    let feed_id: FeedId = expected_feed.id();
+    let feed_id: FeedId = expected_feed.id().unwrap();
     let out_feed: Feed = FeedTrait::from_id(feed_id).unwrap();
     assert(out_feed.asset_class == expected_feed.asset_class, 'Incorrect asset_class');
     assert(out_feed.feed_type == expected_feed.feed_type, 'Incorrect feed_type');
     assert(out_feed.pair_id == expected_feed.pair_id, 'Incorrect pair_id');
-    assert(out_feed.id() == feed_id, 'Incorrect feed id');
+    assert(out_feed.id().unwrap() == feed_id, 'Incorrect feed id');
+
+    let expected_feed = Feed {
+        asset_class: AssetClass::Crypto,
+        feed_type: FeedType::RealizedVolatility(RealizedVolatilityVariant::OneWeek),
+        pair_id: MAX_PAIR_ID - 1,
+    };
+    let feed_id: FeedId = expected_feed.id().unwrap();
+    let out_feed: Feed = FeedTrait::from_id(feed_id).unwrap();
+    assert(out_feed.asset_class == expected_feed.asset_class, 'Incorrect asset_class');
+    assert(out_feed.feed_type == expected_feed.feed_type, 'Incorrect feed_type');
+    assert(out_feed.pair_id == expected_feed.pair_id, 'Incorrect pair_id');
+    assert(out_feed.id().unwrap() == feed_id, 'Incorrect feed id');
 }
 
 
-// #[test]
-// fn test_pair_id_exceeds_max() {
-//     let invalid_feed = Feed {
-//         asset_class: AssetClass::Crypto,
-//         feed_type: FeedType::Unique(UniqueVariant::SpotMedian),
-//         pair_id: MAX_PAIR_ID + 1
-//     };
-//     let feed_id = invalid_feed.id();
-
-//     let result = FeedTrait::from_id(feed_id);
-//     assert(result.is_err(), 'should have errored');
-// }
+#[test]
+fn test_pair_id_exceeds_max() {
+    let invalid_feed = Feed {
+        asset_class: AssetClass::Crypto,
+        feed_type: FeedType::Unique(UniqueVariant::SpotMedian),
+        pair_id: MAX_PAIR_ID + 1
+    };
+    let result = invalid_feed.id();
+    assert(result.is_err(), 'should have errored');
+}
 
 #[test]
 fn test_feed_id_components() {
@@ -56,7 +66,7 @@ fn test_feed_id_components() {
     let pair_id = 'EUR/USD';
 
     let feed = Feed { asset_class, feed_type, pair_id };
-    let feed_id = feed.id();
+    let feed_id = feed.id().unwrap();
 
     let asset_class_component = feed_id / ASSET_CLASS_SHIFT;
     let feed_type_component = (feed_id / FEED_TYPE_SHIFT) & 0xFFFFFFFFFFFFFFFF;


### PR DESCRIPTION
Resolves #34 

## Issues
 
 - The shift and mask definition were inadequate
 - The pair_id range check does not work

## Resolution

Firstly, in cairo a felt252 occupies less than 32 bytes, and more than 31 bytes. For simplicity, we will assume 31 bytes in our case. So if we want to pad the `asset_class` to the left, `asset_class` containing 2 bytes, we will have to apply a 29 bytes shift (`0x10000000000000000000000000000000000000000000000000000000000`) to the asset class value. If we want the `feed_type` to occupy the next 2 bytes we will need to apply a 27 bytes shift (`0x1000000000000000000000000000000000000000000000000000000`). Then we can append the value of pair_id. The previous version did not work because the shifting was not sufficient to fit 9 bytes, where it should be. Secondly, I don't think the pair_id range check works: 
```
 let pair_id = id
            - (asset_class_felt * ASSET_CLASS_SHIFT)
            - (feed_type_id_felt * FEED_TYPE_SHIFT);
```
because if the user specifies an pair_id greater than the max, it will just overflow on the feed_type. For example if we consider 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF + 1 (max_pair_id), we will have 
0x1000000000000000000000000000000000000000000000000000000, so the allocated field to feed_type will have + 1 and the pair_id will be 0, thus lower than MAX_PAIR_ID and this verification: 
```
  if pair_id > MAX_PAIR_ID {
            return Result::Err(FeedError::IdConversion('Pair id greater than 28 bytes'));
        }
```
will always return true. Actually I don't think there is a effective way to make sure that the `pair_id` is in range from the `feed_id`, because it will always overflow. The only way to make sure it's correct is from the `Feed` structure directly. 