### PR TITLE
fix: Dispatch is now an Invoke

### DIFF
--- a/cairo/dispatcher/crates/pragma_dispatcher/src/dispatcher/contract.cairo
+++ b/cairo/dispatcher/crates/pragma_dispatcher/src/dispatcher/contract.cairo
@@ -170,7 +170,7 @@ pub mod PragmaDispatcher {
         ///     This is done in the [add_feed_update_to_message] function.
         ///
         ///  3. Send the updates using the [dispatch] Hyperlane function.
-        fn dispatch(self: @ContractState, feed_ids: Span<FeedId>) -> HyperlaneMessageId {
+        fn dispatch(ref self: ContractState, feed_ids: Span<FeedId>) -> HyperlaneMessageId {
             // [Check] Assert that all feeds id are registered in the Registry
             self.assert_all_feeds_exists(feed_ids.clone());
 
@@ -271,7 +271,7 @@ pub mod PragmaDispatcher {
 
     impl HyperlaneMailboxWrapper of IHyperlaneMailboxWrapper<ContractState> {
         /// Calls dispatch from the Hyperlane Mailbox contract.
-        fn call_dispatch(self: @ContractState, message_body: Bytes) -> HyperlaneMessageId {
+        fn call_dispatch(ref self: ContractState, message_body: Bytes) -> HyperlaneMessageId {
             self
                 .hyperlane_mailbox
                 .read()

--- a/cairo/dispatcher/crates/pragma_dispatcher/src/dispatcher/interface.cairo
+++ b/cairo/dispatcher/crates/pragma_dispatcher/src/dispatcher/interface.cairo
@@ -26,7 +26,7 @@ pub trait IPragmaDispatcher<TContractState> {
 
     /// Dispatch updates through the Hyperlane mailbox for the specifieds
     /// [Span<FeedId>] and return the ID of the message dispatched.
-    fn dispatch(self: @TContractState, feed_ids: Span<FeedId>) -> HyperlaneMessageId;
+    fn dispatch(ref self: TContractState, feed_ids: Span<FeedId>) -> HyperlaneMessageId;
 }
 
 #[starknet::interface]
@@ -44,5 +44,5 @@ pub trait IPragmaFeedsRegistryWrapper<TContractState> {
 #[starknet::interface]
 pub trait IHyperlaneMailboxWrapper<TContractState> {
     /// Calls dispatch from the Hyperlane Mailbox contract.
-    fn call_dispatch(self: @TContractState, message_body: Bytes) -> HyperlaneMessageId;
+    fn call_dispatch(ref self: TContractState, message_body: Bytes) -> HyperlaneMessageId;
 }


### PR DESCRIPTION
Resolves: #NA

## Work done
* `dispatch` from the Dispatcher contract is now an Invoke instead of just a Call.