### PR TITLE
feat(theoros): support for multiple feed ids

### DIFF
--- a/rust/theoros/src/storage/feed_id.rs
+++ b/rust/theoros/src/storage/feed_id.rs
@@ -31,6 +31,13 @@ impl FeedIdsStorage {
         feed_ids.contains(feed_id)
     }
 
+    /// Checks if all feed IDs in the given vector are present in the storage.
+    /// Returns None if all IDs are present, or Some(id) with the first missing ID.
+    pub async fn contains_vec(&self, feed_ids: &[String]) -> Option<String> {
+        let stored_feed_ids = self.0.read().await;
+        feed_ids.iter().find(|id| !stored_feed_ids.contains(*id)).cloned()
+    }
+
     /// Returns the number of feed IDs in the storage.
     pub async fn len(&self) -> usize {
         let feed_ids = self.0.read().await;

--- a/rust/theoros/src/types/pragma/calldata.rs
+++ b/rust/theoros/src/types/pragma/calldata.rs
@@ -88,11 +88,25 @@ pub struct Payload {
 
     pub proof: Vec<String>,
 
+    pub feed_updates: Vec<FeedUpdate>,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct FeedUpdate {
     pub update_data: Vec<u8>,
     /// The id associated to the feed to be updated
     pub feed_id: String,
-
     pub publish_time: u64,
+}
+
+impl AsCalldata for FeedUpdate {
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut bytes = vec![];
+        bytes.extend_from_slice(&self.update_data);
+        bytes.extend_from_slice(self.feed_id.as_bytes());
+        bytes.extend_from_slice(&self.publish_time.to_be_bytes());
+        bytes
+    }
 }
 
 // TODO: these should be tested and follow the abi.encodePacked spec
@@ -107,9 +121,9 @@ impl AsCalldata for Payload {
         for proof in &self.proof {
             bytes.extend_from_slice(proof.as_bytes());
         }
-        bytes.extend_from_slice(&self.update_data);
-        bytes.extend_from_slice(self.feed_id.as_bytes());
-        bytes.extend_from_slice(&self.publish_time.to_be_bytes());
+        for feed_update in &self.feed_updates {
+            bytes.extend_from_slice(&feed_update.as_bytes());
+        }
         bytes
     }
 }


### PR DESCRIPTION
Resolves #77

## Changes
- Moves feed ids param to query parameter
- Adapt `get_calldata` endpoint to support multiple feed ids

## Discussion

Proper specification should be followed for multiple feeds.