### PR TITLE
fix: Cairo package versions

### DIFF
--- a/cairo/dispatcher/Scarb.lock
+++ b/cairo/dispatcher/Scarb.lock
@@ -52,11 +52,12 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
+ "openzeppelin_finance",
  "openzeppelin_governance",
  "openzeppelin_introspection",
  "openzeppelin_merkle_tree",
@@ -69,8 +70,8 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_access"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 dependencies = [
  "openzeppelin_introspection",
  "openzeppelin_utils",
@@ -78,17 +79,26 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_account"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 dependencies = [
  "openzeppelin_introspection",
  "openzeppelin_utils",
 ]
 
 [[package]]
+name = "openzeppelin_finance"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_token",
+]
+
+[[package]]
 name = "openzeppelin_governance"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_introspection",
@@ -96,21 +106,22 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_introspection"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 
 [[package]]
 name = "openzeppelin_merkle_tree"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 
 [[package]]
 name = "openzeppelin_presets"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
+ "openzeppelin_finance",
  "openzeppelin_introspection",
  "openzeppelin_token",
  "openzeppelin_upgrades",
@@ -118,13 +129,13 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_security"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 
 [[package]]
 name = "openzeppelin_token"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 dependencies = [
  "openzeppelin_account",
  "openzeppelin_governance",
@@ -133,13 +144,13 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_upgrades"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 
 [[package]]
 name = "openzeppelin_utils"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 
 [[package]]
 name = "pragma_dispatcher"

--- a/cairo/dispatcher/Scarb.lock
+++ b/cairo/dispatcher/Scarb.lock
@@ -4,7 +4,7 @@ version = 1
 [[package]]
 name = "alexandria_bytes"
 version = "0.1.0"
-source = "git+https://github.com/maxdesalle/alexandria.git#51653c50277491d77ab0783f0ad1d89237c940dd"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 dependencies = [
  "alexandria_data_structures",
  "alexandria_math",
@@ -13,7 +13,7 @@ dependencies = [
 [[package]]
 name = "alexandria_data_structures"
 version = "0.2.0"
-source = "git+https://github.com/maxdesalle/alexandria.git#51653c50277491d77ab0783f0ad1d89237c940dd"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 dependencies = [
  "alexandria_encoding",
 ]
@@ -21,7 +21,7 @@ dependencies = [
 [[package]]
 name = "alexandria_encoding"
 version = "0.1.0"
-source = "git+https://github.com/maxdesalle/alexandria.git#51653c50277491d77ab0783f0ad1d89237c940dd"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 dependencies = [
  "alexandria_bytes",
  "alexandria_math",
@@ -31,12 +31,12 @@ dependencies = [
 [[package]]
 name = "alexandria_math"
 version = "0.2.1"
-source = "git+https://github.com/maxdesalle/alexandria.git#51653c50277491d77ab0783f0ad1d89237c940dd"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 
 [[package]]
 name = "alexandria_numeric"
 version = "0.1.0"
-source = "git+https://github.com/maxdesalle/alexandria.git#51653c50277491d77ab0783f0ad1d89237c940dd"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 dependencies = [
  "alexandria_math",
  "alexandria_searching",
@@ -45,7 +45,7 @@ dependencies = [
 [[package]]
 name = "alexandria_searching"
 version = "0.1.0"
-source = "git+https://github.com/maxdesalle/alexandria.git#51653c50277491d77ab0783f0ad1d89237c940dd"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 dependencies = [
  "alexandria_data_structures",
 ]
@@ -195,13 +195,13 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.1.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.30.0#196f06b251926697c3d66800f2a93ae595e76496"
+version = "0.31.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.31.0#72ea785ca354e9e506de3e5d687da9fb2c1b3c67"
 
 [[package]]
 name = "snforge_std"
-version = "0.30.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.30.0#196f06b251926697c3d66800f2a93ae595e76496"
+version = "0.31.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.31.0#72ea785ca354e9e506de3e5d687da9fb2c1b3c67"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/cairo/dispatcher/Scarb.toml
+++ b/cairo/dispatcher/Scarb.toml
@@ -14,7 +14,7 @@ license-file = "../LICENSE.md"
 starknet = "2.8.2"
 
 # OpenZeppelin components & utilities
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", branch = "upgrade-edition-2024-07" }
+openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.17.0" }
 
 # Pragma Oracle
 pragma_lib = { git = "https://github.com/astraly-labs/pragma-lib", rev = "86d7ccd" }
@@ -31,7 +31,7 @@ pragma_dispatcher = { path = "crates/pragma_dispatcher" }
 pragma_maths = { path = "crates/pragma_maths" }
 
 # Test dependencies
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.30.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.31.0" }
 
 [workspace.tool.fmt]
 sort-module-level-items = true

--- a/cairo/dispatcher/Scarb.toml
+++ b/cairo/dispatcher/Scarb.toml
@@ -22,7 +22,7 @@ pragma_lib = { git = "https://github.com/astraly-labs/pragma-lib", rev = "86d7cc
 # Alexandria (same version than Hyperlane)
 # TODO: Update back to main repository once PR is merged:
 # https://github.com/keep-starknet-strange/alexandria/pull/332
-alexandria_bytes = { git = "https://github.com/maxdesalle/alexandria.git" }
+alexandria_bytes = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "95d98a5" }
 
 # Pragma Dispatcher crates
 pragma_feed_types = { path = "crates/pragma_feed_types" }

--- a/cairo/oracle/Scarb.lock
+++ b/cairo/oracle/Scarb.lock
@@ -4,7 +4,7 @@ version = 1
 [[package]]
 name = "alexandria_bytes"
 version = "0.1.0"
-source = "git+https://github.com/maxdesalle/alexandria.git#51653c50277491d77ab0783f0ad1d89237c940dd"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 dependencies = [
  "alexandria_data_structures",
  "alexandria_math",
@@ -13,7 +13,7 @@ dependencies = [
 [[package]]
 name = "alexandria_data_structures"
 version = "0.2.0"
-source = "git+https://github.com/maxdesalle/alexandria.git#51653c50277491d77ab0783f0ad1d89237c940dd"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 dependencies = [
  "alexandria_encoding",
 ]
@@ -21,7 +21,7 @@ dependencies = [
 [[package]]
 name = "alexandria_encoding"
 version = "0.1.0"
-source = "git+https://github.com/maxdesalle/alexandria.git#51653c50277491d77ab0783f0ad1d89237c940dd"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 dependencies = [
  "alexandria_bytes",
  "alexandria_math",
@@ -31,12 +31,12 @@ dependencies = [
 [[package]]
 name = "alexandria_math"
 version = "0.2.1"
-source = "git+https://github.com/maxdesalle/alexandria.git#51653c50277491d77ab0783f0ad1d89237c940dd"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 
 [[package]]
 name = "alexandria_numeric"
 version = "0.1.0"
-source = "git+https://github.com/maxdesalle/alexandria.git#51653c50277491d77ab0783f0ad1d89237c940dd"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 dependencies = [
  "alexandria_math",
  "alexandria_searching",
@@ -45,7 +45,7 @@ dependencies = [
 [[package]]
 name = "alexandria_searching"
 version = "0.1.0"
-source = "git+https://github.com/maxdesalle/alexandria.git#51653c50277491d77ab0783f0ad1d89237c940dd"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 dependencies = [
  "alexandria_data_structures",
 ]
@@ -53,7 +53,7 @@ dependencies = [
 [[package]]
 name = "alexandria_sorting"
 version = "0.1.0"
-source = "git+https://github.com/maxdesalle/alexandria.git#51653c50277491d77ab0783f0ad1d89237c940dd"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 dependencies = [
  "alexandria_data_structures",
 ]
@@ -61,7 +61,7 @@ dependencies = [
 [[package]]
 name = "alexandria_storage"
 version = "0.3.0"
-source = "git+https://github.com/maxdesalle/alexandria.git#51653c50277491d77ab0783f0ad1d89237c940dd"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 
 [[package]]
 name = "cubit"

--- a/cairo/oracle/Scarb.lock
+++ b/cairo/oracle/Scarb.lock
@@ -70,11 +70,12 @@ source = "git+https://github.com/dojoengine/cubit?branch=cairo_2.7#53020b6320a10
 
 [[package]]
 name = "openzeppelin"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
+ "openzeppelin_finance",
  "openzeppelin_governance",
  "openzeppelin_introspection",
  "openzeppelin_merkle_tree",
@@ -87,8 +88,8 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_access"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 dependencies = [
  "openzeppelin_introspection",
  "openzeppelin_utils",
@@ -96,17 +97,26 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_account"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 dependencies = [
  "openzeppelin_introspection",
  "openzeppelin_utils",
 ]
 
 [[package]]
+name = "openzeppelin_finance"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_token",
+]
+
+[[package]]
 name = "openzeppelin_governance"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_introspection",
@@ -114,21 +124,22 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_introspection"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 
 [[package]]
 name = "openzeppelin_merkle_tree"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 
 [[package]]
 name = "openzeppelin_presets"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
+ "openzeppelin_finance",
  "openzeppelin_introspection",
  "openzeppelin_token",
  "openzeppelin_upgrades",
@@ -136,13 +147,13 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_security"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 
 [[package]]
 name = "openzeppelin_token"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 dependencies = [
  "openzeppelin_account",
  "openzeppelin_governance",
@@ -151,13 +162,13 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_upgrades"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 
 [[package]]
 name = "openzeppelin_utils"
-version = "0.16.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?branch=upgrade-edition-2024-07#b936c3f65ee5ace10a56ec6e3118fdf1ae358952"
+version = "0.17.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.17.0#bf5d02c25c989ccc24f3ab42ec649617d3f21289"
 
 [[package]]
 name = "pragma_entry"
@@ -207,13 +218,13 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.1.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.30.0#196f06b251926697c3d66800f2a93ae595e76496"
+version = "0.31.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.31.0#72ea785ca354e9e506de3e5d687da9fb2c1b3c67"
 
 [[package]]
 name = "snforge_std"
-version = "0.30.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.30.0#196f06b251926697c3d66800f2a93ae595e76496"
+version = "0.31.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.31.0#72ea785ca354e9e506de3e5d687da9fb2c1b3c67"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/cairo/oracle/Scarb.toml
+++ b/cairo/oracle/Scarb.toml
@@ -20,10 +20,10 @@ openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", ta
 # Alexandria (same version than Hyperlane)
 # TODO: Update back to main repository once PR is merged:
 # https://github.com/keep-starknet-strange/alexandria/pull/332
-alexandria_bytes = { git = "https://github.com/maxdesalle/alexandria.git" }
-alexandria_sorting = { git = "https://github.com/maxdesalle/alexandria.git" }
-alexandria_storage = { git = "https://github.com/maxdesalle/alexandria.git" }
-alexandria_math = { git = "https://github.com/maxdesalle/alexandria.git" }
+alexandria_bytes = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "95d98a5" }
+alexandria_sorting = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "95d98a5" }
+alexandria_storage = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "95d98a5" }
+alexandria_math = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "95d98a5" }
 cubit = { git = "https://github.com/dojoengine/cubit", branch = "cairo_2.7" }
 
 

--- a/cairo/oracle/Scarb.toml
+++ b/cairo/oracle/Scarb.toml
@@ -14,7 +14,7 @@ license-file = "../LICENSE.md"
 starknet = "2.8.2"
 
 # OpenZeppelin components & utilities
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", branch = "upgrade-edition-2024-07" }
+openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.17.0" }
 
 
 # Alexandria (same version than Hyperlane)
@@ -35,7 +35,7 @@ pragma_entry = { path = "crates/pragma_entry" }
 pragma_operations = { path = "crates/pragma_operations" }
 
 # Test dependencies
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.30.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.31.0" }
 
 [workspace.tool.fmt]
 sort-module-level-items = true

--- a/rust/theoros/Cargo.toml
+++ b/rust/theoros/Cargo.toml
@@ -22,6 +22,8 @@ lazy_static = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
 opentelemetry = { workspace = true }
+pragma-feeds = { workspace = true }
+pragma-utils = { workspace = true }
 prometheus = { workspace = true }
 rusoto_core = { workspace = true }
 rusoto_s3 = { workspace = true }
@@ -38,5 +40,3 @@ utoipa = { workspace = true, features = ["axum_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
 utoipauto = { workspace = true }
 ya-gcp = { workspace = true }
-pragma-feeds = { workspace = true }
-pragma-utils = { workspace = true }


### PR DESCRIPTION
Resolves: #NA

## Work Done

* We were referencing a branch for `open-zeppelin:cairo_contracts` that does not exists anymore - leading to some errors when building.